### PR TITLE
Deprecate internal code loading; add runtime inclusion option.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "restructuredtext.confPath": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "restructuredtext.confPath": ""
-}

--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ The remote data are originally stored at the remote web-site of one of the
 matrix collections. Before they are presented to the user, they are downloaded
 to local disk storage, which serves as a permanent cache.
 
+By default, the data directory is a scratchspace managed by [`Scratch.jl`](https://github.com/JuliaPackaging/Scratch.jl), but can be changed by setting the `MATRIXDEPOT_DATA` environment variable.
+
+The data directory can be queried by
+
+    julia> MatrixDepot.data_dir()
+    "/home/.../.julia/scratchspaces/MatrixDepot/data"
+
 The occasional user needs not bother about downloads, because that is done in
 the background if matrix files are missing on the local disk.
 

--- a/doc/user.rst
+++ b/doc/user.rst
@@ -12,7 +12,7 @@ be able to use them from Matrix Depot.
 Declaring Generators
 --------------------
 
-Users may override the ``include_generator`` function to declare new
+Users may use the ``include_generator`` function to declare new
 generators. Note that ``include_generator`` must be called at runtime, so
 users creating packages which define custom matrix test suites should place
 their calls to ``include_generator`` in the ``__init__`` function of their

--- a/doc/user.rst
+++ b/doc/user.rst
@@ -12,11 +12,12 @@ be able to use them from Matrix Depot.
 Declaring Generators
 --------------------
 
-When Matrix Depot is first loaded, a new directory ``myMatrixDepot``
-will be created. Matrix Depot automatically includes all Julia files
-in this directory. Hence, all we need to do is to copy
-the generator files to ``path/to/MatrixDepot/myMatrixDepot`` and use
-the function ``include_generator`` to declare them.
+Users may override the ``include_generator`` function to declare new
+generators. Note that ``include_generator`` must be called at runtime, so
+users creating packages which define custom matrix test suites should place
+their calls to ``include_generator`` in the ``__init__`` function of their
+module to avoid
+`precompilation issues <https://docs.julialang.org/en/v2/manual/modules/#Module-initialization-and-precompilation>`_.
 
 .. function:: include_generator(Stuff_To_Be_Included, Stuff, f)
 
@@ -32,8 +33,7 @@ the function ``include_generator`` to declare them.
 Examples
 --------- 
 
-To get a feel of how it works, let's see an example. 
-Suppose we have a file ``myrand.jl`` which contains two 
+To get a feel of how it works, let's see an example. Suppose we have two
 matrix generators ``randsym`` and ``randorth``::
 
   """
@@ -65,35 +65,14 @@ matrix generators ``randsym`` and ``randorth``::
   """
   randorth(n) = Matrix(qr(randn(n,n)).Q)
 
-We first need to find out where the user directory of Matrix Depot is installed. This 
-can be done by::
+We can then write::
 
-    julia> MatrixDepot.user_dir()
-    "/home/.../.julia/dev/MatrixDepot/myMatrixDepot"
+  MatrixDepot.include_generator(FunctionName, "randsym", randsym)
+  MatrixDepot.include_generator(FunctionName, "randorth", randorth)
 
-That points to the default user directory which can be changed by an environment variable::
+and when we are done including generators, we need to reinitializie the database::
 
-    MATRIXDEPOT_USERDIR=/...
-
-The data directory is queried by::
-
-    julia> MatrixDepot.data_dir()
-    "/home/.../.julia/scratchspaces/MatrixDepot/data"
-
-By default, the data directory is managed by ``Scratch.jl``, but can be changed by another environment variable::
-
-    MATRIXDEPOT_DATA=/...
-
-For me, the package user data are installed at
-``/home/.../.julia/dev/MatrixDepot/myMatrixDepot``. We can copy ``myrand.jl`` to this directory.
-Now we open the file
-``myMatrixDepot/generator.jl`` and write::
-
-  include_generator(FunctionName, "randsym", randsym)
-  include_generator(FunctionName, "randorth", randorth)
-
-The changes are activated by re-initializing::
-    julia> MatrixDepot.init()
+  MatrixDepot.init()
 
 This is it. We can now use them from Matrix Depot::
 
@@ -163,13 +142,14 @@ This is it. We can now use them from Matrix Depot::
     5.55112e-17  -2.77556e-17   1.94289e-16   1.0           1.38778e-16
     -6.93889e-17  -5.55112e-17  -1.66533e-16   1.38778e-16   1.0 
 
-We can also add group information in generator.jl::
+We can also add group information with::
 
-    include_generator(Group, :random, randsym)
-    include_generator(Group, :symmetric, randsym)
-    include_generator(Group, :random, randorth)
+    MatrixDepot.include_generator(MatrixDepot.Group, :random, randsym)
+    MatrixDepot.include_generator(MatrixDepot.Group, :symmetric, randsym)
+    MatrixDepot.include_generator(MatrixDepot.Group, :random, randorth)
+    MatrixDepot.init()
 
-After re-initializing ``MatrixDepot`` we can do for example::
+For example::
 
     julia> mdlist(:symmetric)
     22-element Array{String,1}:
@@ -204,16 +184,3 @@ After re-initializing ``MatrixDepot`` we can do for example::
 
 the function ``randsym`` will be part of the groups ``:symmetric`` and ``:random``
 while ``randorth`` is in group ``:random``.
-
-
-It is a good idea to back up your changes. For example, we 
-could save it on GitHub by creating a new repository named ``myMatrixDepot``.
-(See https://help.github.com/articles/create-a-repo/ for details of creating a new repository on GitHub.)
-Then we go to the directory ``.../myMatrixDepot`` and type::
-
-  git init
-  git add *.jl
-  git commit -m "first commit"
-  git remote add origin https://github.com/your-user-name/myMatrixDepot.git
-  git push -u origin master
-

--- a/src/download.jl
+++ b/src/download.jl
@@ -31,8 +31,12 @@ end
 
 function writedb(db::MatrixDatabase)
     cachedb = dbpath(db)
+    #Avoid serializing user matrices, since we don't know which ones will be loaded on deserialization.
+    dbx_data = filter(((key, val),) -> !(val isa GeneratedMatrixData{:U}), db.data)
+    dbx_aliases = filter(((_, key),) -> !(db.data[key] isa GeneratedMatrixData{:U}), db.aliases)
+    dbx = MatrixDatabase(dbx_data, dbx_aliases)
     open(cachedb, "w") do io
-        serialize(io, db)
+        serialize(io, dbx)
     end
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -139,6 +139,7 @@ struct MatrixDatabase
     aliases::Dict{AbstractString,AbstractString}
     MatrixDatabase() = new(Dict{AbstractString,MatrixData}(),
                            Dict{AbstractString,AbstractString}())
+    MatrixDatabase(data, aliases) = new(data, aliases)
 end
 Base.show(io::IO, db::MatrixDatabase) = print(io, "MatrixDatabase(", length(db.data), ")")
 

--- a/test/clean.jl
+++ b/test/clean.jl
@@ -1,8 +1,5 @@
 # setup clean and empty directories
 
-user_dir = abspath(dirname(@__FILE__), "..", "myMatrixDepot")
-data_dir = abspath(dirname(@__FILE__),"..","data")
-
 function save_target(path::AbstractString)
     base = basename(path)
     dir = dirname(path)

--- a/test/include_generator.jl
+++ b/test/include_generator.jl
@@ -32,7 +32,7 @@ n = rand(1:8)
 @test "randsym" in MatrixDepot.mdlist(:random)
 @test "randsym" in MatrixDepot.mdlist(:symmetric)
 
-begin #Testing backward compatibility check deprecation. Delete eventually.
+begin #Testing backward compatibility deprecation. Delete eventually.
     mydepot_warning = "MY_DEPOT_DIR custom code inclusion is deprecated: load custom generators by calling include_generator and reinitializing matrix depot at runtime. For more information, see: https://matrixdepotjl.readthedocs.io/en/latest/user.html. Duplicate warnings will be suppressed."
 
     matrixdata = 

--- a/test/include_generator.jl
+++ b/test/include_generator.jl
@@ -1,5 +1,5 @@
-matrixdata = 
-"""
+import MatrixDepot: include_generator, Group, FunctionName
+
 "random symmetric matrix"
 function randsym(::Type{T}, n) where T
  A = zeros(T, n, n)
@@ -15,12 +15,8 @@ randsym(n) = randsym(Float64, n)
 include_generator(FunctionName, "randsym", randsym)
 include_generator(Group, :random, randsym)
 include_generator(Group, :symmetric, randsym)
-"""
-open(joinpath(MatrixDepot.user_dir(), "generator.jl"), "w") do f
-    write(f, matrixdata)
-end
 
-# include the just written user file
+# update the database
 MatrixDepot.init(ignoredb=true)
 
 n = rand(1:8)
@@ -29,6 +25,33 @@ n = rand(1:8)
 @test "randsym" in MatrixDepot.mdlist(:random)
 @test "randsym" in MatrixDepot.mdlist(:symmetric)
 
-import MatrixDepot: include_generator, Group
-@test_throws ArgumentError include_generator(Group, :lkjasj, sin)
+@test_nowarn MatrixDepot.init()
+n = rand(1:8)
+@test matrixdepot("randsym", n) !== nothing
+@test mdinfo("randsym") != nothing
+@test "randsym" in MatrixDepot.mdlist(:random)
+@test "randsym" in MatrixDepot.mdlist(:symmetric)
 
+begin #Testing backward compatibility check deprecation. Delete eventually.
+    mydepot_warning = "MY_DEPOT_DIR custom code inclusion is deprecated: load custom generators by calling include_generator and reinitializing matrix depot at runtime. For more information, see: https://matrixdepotjl.readthedocs.io/en/latest/user.html. Duplicate warnings will be suppressed."
+
+    matrixdata = 
+    """
+    randorth(n) = Matrix(qr(randn(n,n)).Q)
+    include_generator(FunctionName, "randorth", randorth)
+    include_generator(Group, :random, randorth)
+    """
+    mkpath(MatrixDepot.user_dir())
+    open(joinpath(MatrixDepot.user_dir(), "generator.jl"), "w") do f
+        write(f, matrixdata)
+    end
+
+    @test_logs (:warn, mydepot_warning) MatrixDepot.init()
+    n = rand(1:8)
+
+    @test matrixdepot("randorth", n) !== nothing
+    @test mdinfo("randorth") != nothing
+    @test "randorth" in MatrixDepot.mdlist(:random)
+end
+
+@test_throws ArgumentError include_generator(Group, :lkjasj, sin)


### PR DESCRIPTION
This change would deprecate the custom code loading in MatrixDepot. In particular, this makes three key changes:

1. MatrixDepot will no longer create or write to `MYDEPOT`. While MatrixDepot still reads these files, it will issue a deprecation warning if they are not the default files.
2. MatrixDepot no longer serializes user-defined generators because they may or may not be loaded when the database is deserialized
3. The Documentation now explains the replacement functionality, which directs users to call include_generator from outside of MatrixDepot at runtime, then reinitialize.